### PR TITLE
Refactor game ids, to support China properly

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -35,7 +35,7 @@ class BackendClient(object):
                 self._plugin.lost_authentication()
                 raise
             except Exception as e:
-                logging.log(repr(e))
+                logging.error(repr(e))
                 raise
             return await self.do_request(method, url, data, json, headers, ignore_failure)
 
@@ -152,7 +152,7 @@ class BackendClient(object):
         url = f"{self._authentication_client.blizzard_api_url}/wow/user/characters"
         return await self._authenticated_request("GET", url)
 
-    async def get_wow_character_achievements(self,  realm, character_name):
+    async def get_wow_character_achievements(self, realm, character_name):
         url = f"{self._authentication_client.blizzard_api_url}/wow/character/{realm.lower()}/{character_name}?fields=achievements"
         return await self.do_request("GET", url)
 

--- a/src/definitions.py
+++ b/src/definitions.py
@@ -94,7 +94,7 @@ class _Blizzard(object, metaclass=Singleton):
         BlizzardGame('destiny2', 'Destiny 2', '1146311730', 'DST2', False),
         BlizzardGame('hs_beta', 'Hearthstone', '1465140039', 'WTCG', True),
         BlizzardGame('heroes', 'Heroes of the Storm', '1214607983', 'Hero', True),
-        BlizzardGame('d3cn', '暗黑破壞神III', '?', 'D3CN', False),
+        BlizzardGame('d3cn', '暗黑破壞神III', '17459', 'D3CN', False),
         BlizzardGame('diablo3', 'Diablo III', '17459', 'D3', True),
         BlizzardGame('viper', 'Call of Duty: Black Ops 4', '1447645266', 'VIPR', False),
         BlizzardGame('odin', 'Call of Duty: Modern Warfare', '1329875278', 'ODIN', False),

--- a/src/definitions.py
+++ b/src/definitions.py
@@ -1,18 +1,7 @@
 ﻿import dataclasses as dc
 import json
 import requests
-from typing import Optional, Dict
-from galaxy.api.consts import LicenseType
-
-
-License_Map = {
-    None: LicenseType.Unknown,
-    "Trial": LicenseType.SinglePurchase,
-    "Good": LicenseType.SinglePurchase,
-    "Inactive": LicenseType.SinglePurchase,
-    "Banned": LicenseType.SinglePurchase,
-    "Free": LicenseType.FreeToPlay
-}
+from typing import Optional, Dict, List
 
 
 class DataclassJSONEncoder(json.JSONEncoder):
@@ -29,34 +18,25 @@ class WebsiteAuthData(object):
     region: str
 
 
-
 @dc.dataclass
-class BlizzardGame(object):
-    uid: str
-    name: str
-    blizzard_id: str
-    family: str
-    free_to_play: bool
-
-    @property
-    def id(self):
-        return self.blizzard_id
-
-
-@dc.dataclass
-class ClassicGame(object):
+class BlizzardGame:
     uid: str
     name: str
     family: str
+
+
+@dc.dataclass
+class BattlenetGame(BlizzardGame):
     free_to_play: bool
+
+
+@dc.dataclass
+class ClassicGame(BlizzardGame):
     registry_path: Optional[str] = None
     registry_installation_key: Optional[str] = None
     exe: Optional[str] = None
     bundle_id: Optional[str] = None
 
-    @property
-    def id(self):
-        return self.uid
 
 @dc.dataclass
 class ConfigGameInfo(object):
@@ -84,53 +64,59 @@ class Singleton(type):
 
 
 class _Blizzard(object, metaclass=Singleton):
-    _GAMES = [
-        BlizzardGame('s1', 'StarCraft', '21297', 'S1', True),
-        BlizzardGame('s2', 'StarCraft II', '21298', 'S2', True),
-        BlizzardGame('wow', 'World of Warcraft', '5730135', 'WoW', True),
-        BlizzardGame('wow_classic', 'World of Warcraft Classic', 'wow_classic', 'WoW_wow_classic', False),
-        BlizzardGame('prometheus', 'Overwatch', '5272175', 'Pro', False),
-        BlizzardGame('w3', 'Warcraft III', '?', 'W3', False),
-        BlizzardGame('destiny2', 'Destiny 2', '1146311730', 'DST2', False),
-        BlizzardGame('hs_beta', 'Hearthstone', '1465140039', 'WTCG', True),
-        BlizzardGame('heroes', 'Heroes of the Storm', '1214607983', 'Hero', True),
-        BlizzardGame('d3cn', '暗黑破壞神III', '17459', 'D3CN', False),
-        BlizzardGame('diablo3', 'Diablo III', '17459', 'D3', True),
-        BlizzardGame('viper', 'Call of Duty: Black Ops 4', '1447645266', 'VIPR', False),
-        BlizzardGame('odin', 'Call of Duty: Modern Warfare', '1329875278', 'ODIN', False),
-        ClassicGame('d2', 'Diablo® II', 'Diablo II', False, 'Diablo II', 'DisplayIcon', "Game.exe", "com.blizzard.diabloii"),
-        ClassicGame('d2LOD', 'Diablo® II: Lord of Destruction®', 'Diablo II', False),
-        ClassicGame('w3ROC', 'Warcraft® III: Reign of Chaos',  'Warcraft III', False, 'Warcraft III', 'InstallLocation', 'Warcraft III.exe', 'com.blizzard.WarcraftIII'),
-        ClassicGame('w3tft', 'Warcraft® III: The Frozen Throne®',  'Warcraft III', False, 'Warcraft III', 'InstallLocation', 'Warcraft III.exe', 'com.blizzard.WarcraftIII'),
-        ClassicGame('sca', 'StarCraft® Anthology',  'Starcraft', False, 'StarCraft')
+    BACKEND_ID_UID = {
+        '21297': 's1',
+        '21298': 's2',
+        '5730135': 'wow',
+        '5272175': 'prometheus',
+        '?': 'w3',  # TODO ask for help in Readme
+        '1146311730': 'destiny2',
+        '1465140039': 'hs_beta',
+        '1214607983': 'heroes',
+        '17459': 'diablo3',
+        '1447645266': 'viper',
+        '1329875278': 'odin'
+    }
+    BACKEND_ID_UID_CN = {
+        **BACKEND_ID_UID,
+        '17459': 'd3cn'
+    }
+
+    BATTLENET_GAMES = {
+        BattlenetGame('s1', 'StarCraft', 'S1', True),
+        BattlenetGame('s2', 'StarCraft II', 'S2', True),
+        BattlenetGame('wow', 'World of Warcraft', 'WoW', True),
+        BattlenetGame('wow_classic', 'World of Warcraft Classic', 'WoW_wow_classic', False),
+        BattlenetGame('prometheus', 'Overwatch', 'Pro', False),
+        BattlenetGame('w3', 'Warcraft III', 'W3', False),
+        BattlenetGame('destiny2', 'Destiny 2', 'DST2', False),
+        BattlenetGame('hs_beta', 'Hearthstone', 'WTCG', True),
+        BattlenetGame('heroes', 'Heroes of the Storm', 'Hero', True),
+        BattlenetGame('d3cn', '暗黑破壞神III', 'D3CN', False),
+        BattlenetGame('diablo3', 'Diablo III', 'D3', True),
+        BattlenetGame('viper', 'Call of Duty: Black Ops 4', 'VIPR', False),
+        BattlenetGame('odin', 'Call of Duty: Modern Warfare', 'ODIN', False),
+    }
+
+    CLASSIC_GAMES = [
+        ClassicGame('d2', 'Diablo® II', 'Diablo II', 'Diablo II', 'DisplayIcon', "Game.exe", "com.blizzard.diabloii"),
+        ClassicGame('d2LOD', 'Diablo® II: Lord of Destruction®', 'Diablo II'),  # TODO exe and bundleid
+        ClassicGame('w3ROC', 'Warcraft® III: Reign of Chaos',  'Warcraft III', 'Warcraft III', 'InstallLocation', 'Warcraft III.exe', 'com.blizzard.WarcraftIII'),
+        ClassicGame('w3tft', 'Warcraft® III: The Frozen Throne®',  'Warcraft III', 'Warcraft III', 'InstallLocation', 'Warcraft III.exe', 'com.blizzard.WarcraftIII'),
+        ClassicGame('sca', 'StarCraft® Anthology', 'Starcraft', 'StarCraft')  # TODO exe and bundleid
     ]
 
     def __init__(self):
-        self.__games = {game.id: game for game in self._GAMES}
+        self._games = {game.uid: game for game in self.BATTLENET_GAMES + self.CLASSIC_GAMES}
 
-    def __getitem__(self, key):
-        for game in self._GAMES:
-            if key in [game.id, game.uid, game.name]:
-                return game
-        raise KeyError()
-
-    @property
-    def games(self):
-        return self.__games
-
-    @property
-    def free_games(self):
-        return [game for game in self._GAMES if game.free_to_play]
-
-    @property
-    def legacy_game_ids(self):
-        return [game.uid for game in self._GAMES if isinstance(game, ClassicGame)]
-
-    @property
-    def legacy_games(self):
-        return [game for game in self._GAMES if isinstance(game, ClassicGame)]
+    def __getitem__(self, key: str):
+        try:
+            return self._games[key]
+        except KeyError as e:  # check for family
+            for g in self._games.values():
+                if g.family == key:
+                    return g
+        raise e
 
 
 Blizzard = _Blizzard()
-
-

--- a/src/definitions.py
+++ b/src/definitions.py
@@ -1,8 +1,9 @@
 ﻿import dataclasses as dc
 import json
 import requests
-from typing import Optional
+from typing import Optional, Dict
 from galaxy.api.consts import LicenseType
+
 
 License_Map = {
     None: LicenseType.Unknown,
@@ -13,6 +14,7 @@ License_Map = {
     "Free": LicenseType.FreeToPlay
 }
 
+
 class DataclassJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if dc.is_dataclass(o):
@@ -22,7 +24,7 @@ class DataclassJSONEncoder(json.JSONEncoder):
 
 @dc.dataclass
 class WebsiteAuthData(object):
-    cookie_jar: requests.cookies.RequestsCookieJar()
+    cookie_jar: requests.cookies.RequestsCookieJar
     access_token: str
     region: str
 
@@ -47,10 +49,10 @@ class ClassicGame(object):
     name: str
     family: str
     free_to_play: bool
-    registry_path: str = None
-    registry_installation_key: str = None
-    exe: str = None
-    bundle_id: str = None
+    registry_path: Optional[str] = None
+    registry_installation_key: Optional[str] = None
+    exe: Optional[str] = None
+    bundle_id: Optional[str] = None
 
     @property
     def id(self):
@@ -73,7 +75,7 @@ class ProductDbInfo(object):
 
 
 class Singleton(type):
-    _instances = {}
+    _instances = {}  # type: ignore
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
@@ -104,9 +106,7 @@ class _Blizzard(object, metaclass=Singleton):
     ]
 
     def __init__(self):
-        self.__games = {}
-        for game in self._GAMES:
-            self.__games[game.id] = game
+        self.__games = {game.id: game for game in self._GAMES}
 
     def __getitem__(self, key):
         for game in self._GAMES:

--- a/src/definitions.py
+++ b/src/definitions.py
@@ -66,21 +66,21 @@ class Singleton(type):
 
 class _Blizzard(object, metaclass=Singleton):
     TITLE_ID_MAP = {
-        '21297': RegionalGameInfo('s1', True),
-        '21298': RegionalGameInfo('s2', True),
-        '5730135': RegionalGameInfo('wow', True),
-        '5272175': RegionalGameInfo('prometheus', False),
-        '?': RegionalGameInfo('w3', False),  # TODO ask for help in Readme
-        '1146311730': RegionalGameInfo('destiny2', False),
-        '1465140039': RegionalGameInfo('hs_beta', True),
-        '1214607983': RegionalGameInfo('heroes', True),
-        '17459': RegionalGameInfo('diablo3', True),
-        '1447645266': RegionalGameInfo('viper', False),
-        '1329875278': RegionalGameInfo('odin', False)
+        21297: RegionalGameInfo('s1', True),
+        21298: RegionalGameInfo('s2', True),
+        5730135: RegionalGameInfo('wow', True),
+        5272175: RegionalGameInfo('prometheus', False),
+        -1: RegionalGameInfo('w3', False),  # TODO ask for help in Readme
+        1146311730: RegionalGameInfo('destiny2', False),
+        1465140039: RegionalGameInfo('hs_beta', True),
+        1214607983: RegionalGameInfo('heroes', True),
+        17459: RegionalGameInfo('diablo3', True),
+        1447645266: RegionalGameInfo('viper', False),
+        1329875278: RegionalGameInfo('odin', False)
     }
     TITLE_ID_MAP_CN = {
         **TITLE_ID_MAP,
-        '17459': RegionalGameInfo('d3cn', False)
+        17459: RegionalGameInfo('d3cn', False)
     }
     BATTLENET_GAMES = [
         BlizzardGame('s1', 'StarCraft', 'S1'),
@@ -115,7 +115,7 @@ class _Blizzard(object, metaclass=Singleton):
         """
         return self._games[key]
 
-    def game_by_title_id(self, title_id: str, cn: bool) -> BlizzardGame:
+    def game_by_title_id(self, title_id: int, cn: bool) -> BlizzardGame:
         """
         :param cn: flag if china game definitions should be search though
         :raises KeyError: when unknown title_id for given region

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -13,6 +13,7 @@ from galaxy.api.types import Authentication, NextStep
 from consts import CLIENT_ID, CLIENT_SECRET, REDIRECT_URI, FIREFOX_AGENT
 from region_helper import _found_region, guess_region
 
+
 class AuthenticatedHttpClient(object):
     def __init__(self, plugin):
         self._plugin = plugin
@@ -180,6 +181,7 @@ class AuthenticatedHttpClient(object):
             return "https://www.battlenet.com.cn/oauth"
         else:
             return f"https://{self.region}.battle.net/oauth"
+
     @property
     def blizzard_api_url(self):
         if self.region == 'cn':

--- a/src/local_client.py
+++ b/src/local_client.py
@@ -4,11 +4,13 @@ import asyncio
 import logging as log
 import subprocess
 from time import time
+import pathlib
 
 import psutil
 
 from definitions import ClassicGame
 from consts import Platform, SYSTEM, AGENT_PATH
+from local_client_base import BaseLocalClient
 
 if SYSTEM == Platform.WINDOWS:
     import winreg
@@ -17,8 +19,6 @@ elif SYSTEM == Platform.MACOS:
     from Quartz import CGWindowListCopyWindowInfo, kCGNullWindowID, kCGWindowListExcludeDesktopElements
     from AppKit import NSWorkspace
 
-from local_client_base import BaseLocalClient
-import pathlib
 
 class WinUninstaller(object):
     def __init__(self, path):
@@ -137,11 +137,12 @@ class WinLocalClient(BaseLocalClient):
 
 
 class MacLocalClient(BaseLocalClient):
+    _PATH = "/Applications/Battle.net.app/Contents/MacOS/Battle.net"
+
     def __init__(self, update_statuses):
         super().__init__(update_statuses)
         self.uninstaller = None
         self._exe = self._find_exe()
-    _PATH = "/Applications/Battle.net.app/Contents/MacOS/Battle.net"
 
     def _find_exe(self):
         return self._PATH

--- a/src/local_games.py
+++ b/src/local_games.py
@@ -105,7 +105,7 @@ class LocalGames():
                         log.debug(f"Checking if {game} is in registry ")
                         installed_game = self._add_classic_game(game, key)
                         if installed_game:
-                            classic_games[game.id] = installed_game
+                            classic_games[game.uid] = installed_game
             except OSError as e:
                 log.exception(f"Exception while looking for installed classic games {e}")
         else:
@@ -113,7 +113,7 @@ class LocalGames():
             for game in Blizzard.CLASSIC_GAMES:
                 if game.bundle_id:
                     if game.bundle_id in proc.stdout:
-                        classic_games[game.id] = InstalledGame(
+                        classic_games[game.uid] = InstalledGame(
                                                     game,
                                                     '',
                                                     '1.0',
@@ -185,7 +185,7 @@ class LocalGames():
             for config_game in config_parser_games:
                 installed_game = _add_battlenet_game(config_game, db_game)
                 if installed_game:
-                    games[installed_game.info.id] = installed_game
+                    games[installed_game.info.uid] = installed_game
         self.installed_battlenet_games_lock.acquire()
         self.installed_battlenet_games = games
         self.installed_battlenet_games_lock.release()

--- a/src/local_games.py
+++ b/src/local_games.py
@@ -30,10 +30,6 @@ class InstalledGame(object):
         self.execs = pathfinder.find_executables(self.install_path)
         self._processes = set()
 
-    @property
-    def local_game_args(self):
-        return (self.info.blizzard_id, self.is_running)
-
     def add_process(self, process: Process):
         try:
             if process.exe() in self.execs:
@@ -59,6 +55,7 @@ class InstalledGame(object):
     def wait_until_game_stops(self):
         while self.is_running():
             time.sleep(0.5)
+
 
 class LocalGames():
     def __init__(self):
@@ -170,7 +167,7 @@ class LocalGames():
                 log.warning(f'[{config_game.uid}] is not known blizzard game. Skipping')
                 return None
             try:
-                log.info(f"Adding {blizzard_game.blizzard_id} {blizzard_game.name} to installed games")
+                log.info(f"Adding {blizzard_game.uid} {blizzard_game.name} to installed games")
                 return InstalledGame(
                     blizzard_game,
                     config_game.uninstall_tag,

--- a/src/local_games.py
+++ b/src/local_games.py
@@ -104,7 +104,7 @@ class LocalGames():
             try:
                 reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
                 with winreg.OpenKey(reg, WINDOWS_UNINSTALL_LOCATION) as key:
-                    for game in Blizzard.legacy_games:
+                    for game in Blizzard.CLASSIC_GAMES:
                         log.debug(f"Checking if {game} is in registry ")
                         installed_game = self._add_classic_game(game, key)
                         if installed_game:
@@ -113,7 +113,7 @@ class LocalGames():
                 log.exception(f"Exception while looking for installed classic games {e}")
         else:
             proc = subprocess.run([LS_REGISTER,"-dump"], encoding='utf-8',stdout=subprocess.PIPE)
-            for game in Blizzard.legacy_games:
+            for game in Blizzard.CLASSIC_GAMES:
                 if game.bundle_id:
                     if game.bundle_id in proc.stdout:
                         classic_games[game.id] = InstalledGame(

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "name": "Galaxy Battle.net plugin",
     "platform": "battlenet",
     "guid": "ba170431-0649-482f-863b-d248592f1842",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Galaxy Battle.net plugin",
     "author": "FriendsOfGalaxy; bartok765; wanze; saitho; elkangaroo",
     "email": "bartok765@protonmail.com",

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -178,10 +178,6 @@ class BNetPlugin(Plugin):
             await self.get_local_games()
 
         try:
-            if self.local_client.get_installed_games() is None:
-                log.error(f'Launching game that is not installed: {game_id}')
-                return await self.install_game(game_id)
-
             game = self.local_client.get_installed_games().get(game_id, None)
             if game is None:
                 log.error(f'Launching game that is not installed: {game_id}')

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -269,7 +269,7 @@ class BNetPlugin(Plugin):
         def _parse_battlenet_games(standard_games: dict, cn: bool) -> Dict[BlizzardGame, LicenseType]:
             licenses = {
                 None: LicenseType.Unknown,
-                "Trial": LicenseType.SinglePurchase,
+                "Trial": LicenseType.OtherUserLicense,
                 "Good": LicenseType.SinglePurchase,
                 "Inactive": LicenseType.SinglePurchase,
                 "Banned": LicenseType.SinglePurchase,

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -44,7 +44,7 @@ class BNetPlugin(Plugin):
     async def _notify_about_game_stop(self, game, starting_timeout):
         if not self.local_games_called:
             return
-        id_to_watch = game.info.id
+        id_to_watch = game.info.uid
 
         if id_to_watch in self.watched_running_games:
             log.debug(f'Game {id_to_watch} is already watched. Skipping')

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -158,7 +158,7 @@ class BNetPlugin(Plugin):
                 installed_game = self.local_client.get_installed_games().get(game_id, None)
 
                 if installed_game is None or not os.access(installed_game.install_path, os.F_OK):
-                    log.error(f'Cannot uninstall {Blizzard[game_id].uid}')
+                    log.error(f'Cannot uninstall {game_id}')
                     self.update_local_game_status(LocalGame(game_id, LocalGameState.None_))
                     return
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -334,14 +334,14 @@ class BNetPlugin(Plugin):
             installed_games = self.local_client.get_installed_games()
             log.info(f"Installed games {installed_games.items()}")
             log.info(f"Running games {running_games}")
-            for id_, game in installed_games.items():
+            for uid, game in installed_games.items():
                 if game.playable:
                     state = LocalGameState.Installed
-                    if id_ in running_games:
+                    if uid in running_games:
                         state |= LocalGameState.Running
                 else:
                     state = LocalGameState.None_
-                translated_installed_games.append(LocalGame(id_, state))
+                translated_installed_games.append(LocalGame(uid, state))
             self.local_client.installed_games_cache = installed_games
             return translated_installed_games
 

--- a/src/process.py
+++ b/src/process.py
@@ -27,10 +27,10 @@ class ProcessProvider(object):
             for game in games:
                 if proc.info['exe'] in game.execs:
                     game.add_process(proc)
-                    running_games.add(game.info.id)
+                    running_games.add(game.info.uid)
                 if isinstance(game.info, ClassicGame):
                     if game.info.exe in proc.info['name']:
                         game.add_process(proc)
-                        running_games.add(game.info.id)
+                        running_games.add(game.info.uid)
 
         return running_games

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,0 +1,35 @@
+import pytest
+from definitions import Blizzard, BlizzardGame
+
+
+def test_blizzard_getitem_no_item():
+    with pytest.raises(KeyError):
+        Blizzard['-1']
+
+
+def test_blizzard_getitem_by_uid():
+    for game in Blizzard.BATTLENET_GAMES + Blizzard.CLASSIC_GAMES:
+        assert Blizzard[game.uid] == game
+
+
+def test_blizzard_game_by_title_id_no_item():
+    with pytest.raises(KeyError):
+        Blizzard.game_by_title_id('-1', cn=False)
+
+
+@pytest.mark.parametrize('cn, title_id, expected', [
+    (True, '17459', Blizzard['d3cn']),
+    (False, '17459', Blizzard['diablo3']),
+    (True, '21297', Blizzard['s1']),
+    (False, '21297', Blizzard['s1'])
+])
+def test_blizzard_game_by_title_id_cn(cn, title_id, expected):
+    """d3cn should overwrite diablo3 for cn region"""
+    assert Blizzard.game_by_title_id(title_id, cn) == expected
+
+
+def test_try_for_free_games_no_d3cn():
+    assert Blizzard['diablo3'] in Blizzard.try_for_free_games(cn=False)
+    assert Blizzard['d3cn'] not in Blizzard.try_for_free_games(cn=False)
+    # diablo3 not available for free in china
+    assert Blizzard['d3cn'] not in Blizzard.try_for_free_games(cn=True)

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -14,14 +14,14 @@ def test_blizzard_getitem_by_uid():
 
 def test_blizzard_game_by_title_id_no_item():
     with pytest.raises(KeyError):
-        Blizzard.game_by_title_id('-1', cn=False)
+        Blizzard.game_by_title_id(-100, cn=False)
 
 
 @pytest.mark.parametrize('cn, title_id, expected', [
-    (True, '17459', Blizzard['d3cn']),
-    (False, '17459', Blizzard['diablo3']),
-    (True, '21297', Blizzard['s1']),
-    (False, '21297', Blizzard['s1'])
+    (True, 17459, Blizzard['d3cn']),
+    (False, 17459, Blizzard['diablo3']),
+    (True, 21297, Blizzard['s1']),
+    (False, 21297, Blizzard['s1'])
 ])
 def test_blizzard_game_by_title_id_cn(cn, title_id, expected):
     """d3cn should overwrite diablo3 for cn region"""

--- a/tests/test_game_time.py
+++ b/tests/test_game_time.py
@@ -13,7 +13,7 @@ from src.parsers import ConfigParser
 # pytest-asyncio: all test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
 
-OW_ID = '5272175'
+OW_ID = 'prometheus'
 NO_GAME_TIME = GameTime(OW_ID, None, None)
 
 
@@ -76,18 +76,18 @@ async def test_last_played_when_unknown_game_in_config(pg, config_parser):
         ConfigGameInfo(game.uid, 'diablo3_enus', '1441712029')
     ]
 
-    ctx = await pg.prepare_game_times_context([game.blizzard_id])
-    result = await pg.get_game_time(game.blizzard_id, ctx)
-    assert result.game_id == game.blizzard_id
+    ctx = await pg.prepare_game_times_context([game.uid])
+    result = await pg.get_game_time(game.uid, ctx)
+    assert result.game_id == game.uid
     assert result.last_played_time == 1441712029
 
 async def test_last_played_time(pg, config_data):
     pg.local_client.config_parser = ConfigParser(config_data)
 
-    ctx = await pg.prepare_game_times_context(["21298", "1214607983"])
+    ctx = await pg.prepare_game_times_context(["s2", "heroes"])
 
-    result = await pg.get_game_time("21298", ctx)
-    assert result == GameTime("21298", None, None)
+    result = await pg.get_game_time("s2", ctx)
+    assert result == GameTime("s2", None, None)
 
-    result = await pg.get_game_time("1214607983", ctx)
-    assert result == GameTime("1214607983", None, 1441712029)
+    result = await pg.get_game_time("heroes", ctx)
+    assert result == GameTime("heroes", None, 1441712029)

--- a/tests/test_owned_games.py
+++ b/tests/test_owned_games.py
@@ -5,89 +5,54 @@ import json
 from galaxy.api.types import Game, LicenseInfo
 from galaxy.api.consts import LicenseType
 
-from tests.website_mocks import backend_owned_games
+from definitions import Blizzard
+from tests.website_mocks import backend_owned_games, backend_no_classics, backend_classic_games
 
 
 @pytest.fixture
 def result_owned_games():
     vals = [
-        {
-            "game_id": "5730135",
-            "game_title": "World of Warcraft\u00ae",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "1329875278",
-            "game_title": "Call of Duty: Modern Warfare",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "17459",
-            "game_title": "Diablo\u00ae\u00a0III",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "1465140039",
-            "game_title": "Hearthstone\u00ae",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "1214607983",
-            "game_title": "Heroes of the Storm\u00ae",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "5272175",
-            "game_title": "Overwatch\u00ae",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "21298",
-            "game_title": "StarCraft\u00ae\u00a0II",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "21297",
-            "game_title": "StarCraft\u00ae Remastered",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "1146311730",
-            "game_title": "Destiny 2",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
-        {
-            "game_id": "wow_classic",
-            "game_title": "World of Warcraft Classic",
-            "dlcs": [],
-            "license_info": {"license_type": "SinglePurchase"},
-        },
+        Blizzard['wow'],
+        Blizzard['destiny2'],
+        Blizzard['odin'],
+        Blizzard['s1'],
+        Blizzard['s2'],
+        Blizzard['prometheus'],
+        Blizzard['diablo3'],
+        Blizzard['hs_beta'],
+        Blizzard['heroes'],
+        Blizzard['wow_classic']
     ]
 
     return [
-        Game(game["game_id"], game["game_title"], [], LicenseInfo(LicenseType.SinglePurchase))
+        Game(game.uid, game.name, None, LicenseInfo(LicenseType.SinglePurchase))
         for game in vals
     ]
 
 
 @pytest.fixture
-def backend_no_classics():
-    return json.loads("""{ "classicGames": [] } """)
+def result_classic_games():
+    return [
+        Game('d2', 'Diablo® II', None, LicenseInfo(LicenseType.SinglePurchase)),
+    ]
 
 
 @pytest.mark.asyncio
-async def test_all_games(pg, backend_mock, backend_owned_games, backend_no_classics, result_owned_games):
+async def test_owned_games(pg, backend_mock, backend_owned_games, backend_no_classics, result_owned_games):
     backend_mock.get_owned_games.return_value = backend_owned_games
     backend_mock.get_owned_classic_games.return_value = backend_no_classics
 
     result = await pg.get_owned_games()
-    assert result == result_owned_games
+    assert sorted(result, key=lambda x: x.game_id) == sorted(result_owned_games, key=lambda x: x.game_id)
+
+
+@pytest.mark.asyncio
+async def test_integration(
+    pg, backend_mock, backend_owned_games, backend_classic_games, result_owned_games, result_classic_games
+):
+    backend_mock.get_owned_games.return_value = backend_owned_games
+    backend_mock.get_owned_classic_games.return_value = backend_classic_games
+
+    result = await pg.get_owned_games()
+    assert sorted(result, key=lambda x: x.game_id) == sorted(result_owned_games + result_classic_games, key=lambda x: x.game_id)
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,4 @@
 import pytest
-from definitions import Blizzard, BlizzardGame
 from parsers import DatabaseParser, ProductDbInfo, ConfigParser, ConfigGameInfo
 
 
@@ -43,19 +42,8 @@ def test_db_parser2(another_database):
     parser = DatabaseParser(another_database)
     assert parser.products.get('s1') == ProductDbInfo('s1', 's1', 'D:/bnet/StarCraft', '1.22.3.5354', True)
 
+
 def test_db_parser3_games_under_installation(db_under_installation):
     prs = DatabaseParser(db_under_installation)
     assert prs.products.get('s1') == ProductDbInfo('s1', 's1', 'C:/Program Files (x86)/StarCraft', '', False)
     assert prs.products.get('hero') == ProductDbInfo('heroes', 'hero', 'C:/Program Files (x86)/Heroes of the Storm', '2.43.3.72649', True)
-
-def test_blizzard_object():
-    try:
-        x = Blizzard['-1']
-        pytest.fail(f"Should raise exception - no blizzard game with ID -1, {x}")
-    except:
-        pass
-
-    game = BlizzardGame('destiny2', 'Destiny 2', '1146311730', 'DST2', False)
-    assert Blizzard['destiny2'] == game
-    assert Blizzard['Destiny 2'] == game
-    assert Blizzard['1146311730'] == game

--- a/tests/website_mocks.py
+++ b/tests/website_mocks.py
@@ -238,6 +238,25 @@ def backend_owned_games():
 
 
 @pytest.fixture
+def backend_no_classics():
+    return json.loads("""{ "classicGames": [] } """)
+
+
+@pytest.fixture
+def backend_classic_games():
+    return json.loads("""
+{"classicGames": [
+    {
+        "localizedGameName":"Diablo® II",
+        "regionalGameFranchiseIconFilename":"diablo-ii.svg",
+        "cdKeys":["XXXXXXXXXXXXXXXXXXXXXXXXXX"],
+        "displayOrder":9003
+    }
+]}
+""")
+
+
+@pytest.fixture
 async def sc2_player_data(self):
     return json.loads(
         """[{"name": "MOCK", "profileUrl": "https://www.starcraft2.com/profile/2/1/123", "avatarUrl": "https://static.starcraft2.com/starport/eadc1041-1c53-4c27-bf45-303ac5c6e33f/portraits/13-4.jpg", "profileId": "420", "regionId": 2, "realmId": 1}]"""


### PR DESCRIPTION
Fixes #15 
Closes (supersedes) #19 

- [x] get_owned_games: send uid instead of blizzard_id (transition blizzard_id -> uid)
- [x] handle classic games
- [x] install
- [x] uninstall
- [x] launch
- [x] get_game_time
- [x] tests