### PR TITLE
Workaround for Login Timeout

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -41,7 +41,6 @@ class BackendClient(object):
 
     @staticmethod
     def handle_status_code(status_code):
-        logging.debug(f'Status code: {status_code}')
         if status_code == HTTPStatus.UNAUTHORIZED:
             raise AuthenticationRequired()
         if status_code == HTTPStatus.FORBIDDEN:
@@ -70,11 +69,13 @@ class BackendClient(object):
             try:
                 response = await loop.run_in_executor(None, functools.partial(self._authentication_client.session.request, **params))
             except (requests.Timeout, requests.ConnectTimeout, requests.ReadTimeout):
+                logging.debug(f'Request to {url} timed out')
                 raise BackendTimeout()
             except requests.ConnectionError:
                 raise NetworkError
 
             if not ignore_failure:
+                logging.debug(f'Request to {url} responsed with status code {response.status_code}')
                 self.handle_status_code(response.status_code)
 
             if json:

--- a/src/http_client.py
+++ b/src/http_client.py
@@ -21,7 +21,7 @@ class AuthenticatedHttpClient(object):
         self._region = None
         self.session = None
         self.creds = None
-        self.timeout = 10.0
+        self.timeout = 20.0
         self.attempted_to_set_battle_tag = None
         self.auth_data = None
 


### PR DESCRIPTION
Workaround for #35 

Increases timeout of AuthenticatedHttpClient from 10 to 20 seconds, because currently requests to https://eu.account.blizzard.com:443/oauth2/authorization/account-settings time out (most of the time) otherwise.

Also debug logs http requests for future issues.