### PR TITLE
Send local games states notifications on start (do not rely on whether Galaxy call get_local_games)

### DIFF
--- a/src/local_client_base.py
+++ b/src/local_client_base.py
@@ -52,9 +52,6 @@ class BaseLocalClient(abc.ABC):
         self.uninstaller = None
         self.installed_games_cache = self.get_installed_games()
 
-        loop = asyncio.get_event_loop()
-        loop.create_task(self._register_local_data_watcher())
-        loop.create_task(self._register_classic_games_updater())
         self.classic_games_parsing_task = None
 
     @abc.abstractproperty
@@ -207,7 +204,7 @@ class BaseLocalClient(abc.ABC):
                 raise e
         return True
 
-    async def _register_local_data_watcher(self):
+    async def register_local_data_watcher(self):
         parse_local_data_event = asyncio.Event()
         FileWatcher(self.CONFIG_PATH, parse_local_data_event, interval=1)
         FileWatcher(self.PRODUCT_DB_PATH, parse_local_data_event, interval=2.5)
@@ -228,7 +225,7 @@ class BaseLocalClient(abc.ABC):
             self.installed_games_cache = refreshed_games
             parse_local_data_event.clear()
 
-    async def _register_classic_games_updater(self):
+    async def register_classic_games_updater(self):
         tick_count = 0
         while True:
             tick_count += 1

--- a/src/local_games.py
+++ b/src/local_games.py
@@ -33,7 +33,6 @@ class InstalledGame(object):
     @property
     def has_galaxy_installed_state(self) -> bool:
         """Indicates when Play button should be available in Galaxy"""
-
         return self.playable or self.installed
 
     def add_process(self, process: Process):

--- a/tests/test_local_games.py
+++ b/tests/test_local_games.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock, patch, call
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import pytest
 
@@ -97,7 +97,12 @@ class BlizzardGameState(NamedTuple):
         id="game uninstalled"
     ),
 ])
-def test_local_game_installation_state_notification(plugin_mock, prev, refr, new_state):
+def test_local_game_installation_state_notification(
+    plugin_mock,
+    prev: Optional[BlizzardGameState],
+    refr: Optional[BlizzardGameState],
+    new_state: Optional[LocalGameState]
+):
 
     def installed_game(playable: bool, installed: bool):
         with patch('local_games.pathfinder'):
@@ -108,16 +113,16 @@ def test_local_game_installation_state_notification(plugin_mock, prev, refr, new
             )
 
     plugin_mock.update_local_game_status = Mock()
-    game_id = 's1'
-    previous_games = {game_id: installed_game(prev.playable, prev.installed)} if prev else {}
-    refreshed_games = {game_id: installed_game(refr.playable, refr.installed)} if refr else {}
+    GAME_ID = 's1'
+    previous_games = {GAME_ID: installed_game(prev.playable, prev.installed)} if prev else {}
+    refreshed_games = {GAME_ID: installed_game(refr.playable, refr.installed)} if refr else {}
     
     plugin_mock._update_statuses(refreshed_games, previous_games)
 
     if new_state is None:
         plugin_mock.update_local_game_status.assert_not_called()
     else:
-        local_game = LocalGame(game_id, new_state)
+        local_game = LocalGame(GAME_ID, new_state)
         plugin_mock.update_local_game_status.assert_called_once_with(local_game)
 
 
@@ -127,25 +132,26 @@ def test_local_game_installation_state_notification(plugin_mock, prev, refr, new
     pytest.param('11111111', '12222222', LocalGameState.Running | LocalGameState.Installed, id="game started"),
 ])
 def test_local_game_running_state_notification(
-    plugin_mock, prev_last_played, refr_last_played, new_state
+    plugin_mock,
+    prev_last_played: str,
+    refr_last_played: str,
+    new_state: Optional[LocalGameState]
 ):
     # patch side-effects
     plugin_mock._notify_about_game_stop = Mock()
     plugin_mock.create_task = Mock()
 
     plugin_mock.update_local_game_status = Mock()
-    game_id = 's1'
-    prev = Mock(InstalledGame, has_galaxy_installed_state=True, last_played=prev_last_played)
-    refr = Mock(InstalledGame, has_galaxy_installed_state=True, last_played=refr_last_played)
-    previous_games = {game_id: prev}
-    refreshed_games = {game_id: refr}
+    GAME_ID = 's1'
+    previous_games = {GAME_ID: Mock(InstalledGame, has_galaxy_installed_state=True, last_played=prev_last_played)}
+    refreshed_games = {GAME_ID: Mock(InstalledGame, has_galaxy_installed_state=True, last_played=refr_last_played)}
     
     plugin_mock._update_statuses(refreshed_games, previous_games)
 
     if new_state is None:
         plugin_mock.update_local_game_status.assert_not_called()
     else:
-        local_game = LocalGame(game_id, new_state)
+        local_game = LocalGame(GAME_ID, new_state)
         plugin_mock.update_local_game_status.assert_called_once_with(local_game)
 
 

--- a/tests/test_local_games.py
+++ b/tests/test_local_games.py
@@ -1,9 +1,12 @@
+from unittest.mock import Mock, patch
+from typing import NamedTuple
+
 import pytest
 
 from galaxy.api.types import LocalGame
 from galaxy.api.consts import LocalGameState
 
-from src.local_games import InstalledGame
+from local_games import InstalledGame
 from definitions import Blizzard
 
 
@@ -17,12 +20,130 @@ from definitions import Blizzard
 async def test_local_games_states(plugin_mock, installed, playable, expected_state):
     plugin_mock.local_client.get_running_games.return_value = set()
     plugin_mock.local_client.get_installed_games.return_value = {
-        "test_game_id_1": InstalledGame(Blizzard['s1'], 's1', '1.0', '', '/path/', playable, installed),
+        "s1": InstalledGame(Blizzard['s1'], 's1', '1.0', '', '/path/', playable, installed),
     }
-
     expected_local_games = [
-        LocalGame("test_game_id_1", expected_state)
+        LocalGame("s1", expected_state)
     ]
 
     result = await plugin_mock.get_local_games()
     assert result == expected_local_games
+
+
+class BlizzardGameState(NamedTuple):
+    playable: bool
+    installed: bool
+
+
+@pytest.mark.parametrize("prev, refr, new_state", [
+    pytest.param(
+        BlizzardGameState(True, True),
+        BlizzardGameState(True, True),
+        None,
+        id="no change; game playable"
+    ),
+    pytest.param(
+        None,
+        BlizzardGameState(False, False), 
+        None,
+        id="game installation began or first iteration after plugin start"
+    ),
+    pytest.param(
+        None,
+        BlizzardGameState(True, False), 
+        LocalGameState.Installed,
+        id="first iteration after plugin start: game is playable"
+    ),
+    pytest.param(
+        None,
+        BlizzardGameState(False, True), 
+        LocalGameState.Installed,
+        id="first iteration after plugin start: game not playable but installed (eg. update pending)"
+    ),
+    pytest.param(
+        BlizzardGameState(False, False), 
+        BlizzardGameState(True, True), 
+        LocalGameState.Installed,
+        id="game installation finished"
+    ),
+    pytest.param(
+        BlizzardGameState(False, False), 
+        BlizzardGameState(True, False), 
+        LocalGameState.Installed,
+        id="game became playable during installation"
+    ),
+    pytest.param(
+        BlizzardGameState(True, False),
+        BlizzardGameState(True, True), 
+        None,
+        id="playable game fully installed"
+    ),
+    pytest.param(
+        BlizzardGameState(True, True),
+        BlizzardGameState(False, True), 
+        None,
+        id="game update appeared"
+    ),
+    pytest.param(
+        BlizzardGameState(False, True),
+        BlizzardGameState(True, True), 
+        None,
+        id="game update finished"
+    ),
+    pytest.param(
+        BlizzardGameState(True, True), 
+        None, 
+        LocalGameState.None_,
+        id="game uninstalled"
+    ),
+])
+def test_local_game_installation_state_notification(plugin_mock, prev, refr, new_state):
+
+    def installed_game(playable: bool, installed: bool):
+        with patch('local_games.pathfinder'):
+            last_played = ''  # to not affect the logic for running game detection
+            return InstalledGame(
+                Mock(Blizzard), Mock(str), Mock(str), last_played, Mock(str),
+                playable=playable, installed=installed
+            )
+
+    plugin_mock.update_local_game_status = Mock()
+    game_id = 's1'
+    previous_games = {game_id: installed_game(prev.playable, prev.installed)} if prev else {}
+    refreshed_games = {game_id: installed_game(refr.playable, refr.installed)} if refr else {}
+    
+    plugin_mock._update_statuses(refreshed_games, previous_games)
+
+    if new_state is None:
+        plugin_mock.update_local_game_status.assert_not_called()
+    else:
+        local_game = LocalGame(game_id, new_state)
+        plugin_mock.update_local_game_status.assert_called_once_with(local_game)
+
+
+@pytest.mark.parametrize("prev_last_played, refr_last_played, new_state", [
+    pytest.param('', '', None, id="game never played on this machine"),
+    pytest.param('', '123123123', LocalGameState.Running | LocalGameState.Installed, id="game started for the first time on this machine"),
+    pytest.param('11111111', '12222222', LocalGameState.Running | LocalGameState.Installed, id="game started"),
+])
+def test_local_game_running_state_notification(
+    plugin_mock, prev_last_played, refr_last_played, new_state
+):
+    # patch side-effects
+    plugin_mock._notify_about_game_stop = Mock()
+    plugin_mock.create_task = Mock()
+
+    plugin_mock.update_local_game_status = Mock()
+    game_id = 's1'
+    prev = Mock(InstalledGame, has_galaxy_installed_state=True, last_played=prev_last_played)
+    refr = Mock(InstalledGame, has_galaxy_installed_state=True, last_played=refr_last_played)
+    previous_games = {game_id: prev}
+    refreshed_games = {game_id: refr}
+    
+    plugin_mock._update_statuses(refreshed_games, previous_games)
+
+    if new_state is None:
+        plugin_mock.update_local_game_status.assert_not_called()
+    else:
+        local_game = LocalGame(game_id, new_state)
+        plugin_mock.update_local_game_status.assert_called_once_with(local_game)

--- a/tests/test_owned_games.py
+++ b/tests/test_owned_games.py
@@ -1,6 +1,4 @@
-import asyncio
 import pytest
-import json
 
 from galaxy.api.types import Game, LicenseInfo
 from galaxy.api.consts import LicenseType


### PR DESCRIPTION
Fixes #40 

- removes boolean that prevented local game states notification if get_local_games was not called at least once (I don't know what was the initial purpose of this logic). Instead start watching local files and registry after `handshake_complete` method is called. Before this method is called all notifications about local game statuses are ignored by Galax
- add tests for `update_local_game_status` notifications
- remove redundant notification with `LocalGameState.None_` when not-fully installed and not playable game is detected