### PR TITLE
Do not return local games with LocalGameState.None_

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -336,8 +336,6 @@ class BNetPlugin(Plugin):
                     if uid in running_games:
                         state |= LocalGameState.Running
                     translated_installed_games.append(LocalGame(uid, state))
-                else:
-                    state = LocalGameState.None_
             self.local_client.installed_games_cache = installed_games
             return translated_installed_games
 

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -335,9 +335,9 @@ class BNetPlugin(Plugin):
                     state = LocalGameState.Installed
                     if uid in running_games:
                         state |= LocalGameState.Running
+                    translated_installed_games.append(LocalGame(uid, state))
                 else:
                     state = LocalGameState.None_
-                translated_installed_games.append(LocalGame(uid, state))
             self.local_client.installed_games_cache = installed_games
             return translated_installed_games
 

--- a/tests/test_local_games.py
+++ b/tests/test_local_games.py
@@ -14,20 +14,32 @@ from definitions import Blizzard
     (True, True, LocalGameState.Installed),
     (True, False, LocalGameState.Installed),
     (False, True, LocalGameState.Installed),
-    (False, False, LocalGameState.None_),
 ])
 @pytest.mark.asyncio
-async def test_local_games_states(plugin_mock, installed, playable, expected_state):
-    plugin_mock.local_client.get_running_games.return_value = set()
-    plugin_mock.local_client.get_installed_games.return_value = {
-        "s1": InstalledGame(Blizzard['s1'], 's1', '1.0', '', '/path/', playable, installed),
-    }
+async def test_get_local_games_installed(plugin_mock, installed, playable, expected_state):
     expected_local_games = [
         LocalGame("s1", expected_state)
     ]
 
-    result = await plugin_mock.get_local_games()
-    assert result == expected_local_games
+    plugin_mock.local_client.get_running_games.return_value = set()
+    plugin_mock.local_client.get_installed_games.return_value = {
+        "s1": InstalledGame(Blizzard['s1'], 's1', '1.0', '', '/path/', playable, installed),
+    }
+
+    assert await plugin_mock.get_local_games() == expected_local_games
+
+
+@pytest.mark.asyncio
+async def test_get_local_games_not_installed(plugin_mock):
+    playable, installed = False, False
+    expected_local_games = []
+
+    plugin_mock.local_client.get_running_games.return_value = set()
+    plugin_mock.local_client.get_installed_games.return_value = {
+        "s1": InstalledGame(Blizzard['s1'], 's1', '1.0', '', '/path/', playable, installed),
+    }
+    
+    assert await plugin_mock.get_local_games() == expected_local_games
 
 
 class BlizzardGameState(NamedTuple):


### PR DESCRIPTION
Workaround on probable bug in Galaxy. See https://github.com/tylerbrawl/Galaxy-Plugin-Rockstar/issues/108

- also notification with state `None_` when previously seen game was not installed was removed in #47 