### PR TITLE
Workaround Galaxy not ready on handshake_complete

### DIFF
--- a/src/local_client_base.py
+++ b/src/local_client_base.py
@@ -7,7 +7,6 @@ from time import time
 from pathlib import Path
 from typing import Dict
 
-from definitions import Blizzard
 from process import ProcessProvider
 from consts import Platform, SYSTEM, CONFIG_PATH, AGENT_PATH
 from watcher import FileWatcher

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -41,6 +41,14 @@ class BNetPlugin(Plugin):
         self.watched_running_games = set()
     
     def handshake_complete(self):
+        self.create_task(self.__delayed_handshake(), 'delayed handshake')
+
+    async def __delayed_handshake(self):
+        """
+        Adds some minimal delay on Galaxy start before registering local data watchers.
+        Apparently Galaxy may be not ready to receive notifications even after handshake_complete.
+        """
+        await asyncio.sleep(1)
         self.create_task(self.local_client.register_local_data_watcher(), 'local data watcher')
         self.create_task(self.local_client.register_classic_games_updater(), 'classic games updater')
 


### PR DESCRIPTION
Last fix #47 for bug in Galaxy may not work sometimes (race condition), because we send notifications very quickly on plugin start - right after `handshake_complete`. Looks like waiting to this method call with all initialization on Galaxy side is currently unsupported. In such case, Install button is gray-out, so it looks even worse that previously. Most of the time the race condition on my machine was a matter of tens of miliseconds eg.

plugin log:
```
2021-02-01 11:39:08,861 - galaxy.api.jsonrpc - INFO - Sending notification: method=local_game_status_changed, params={'local_game': LocalGame(game_id='hs_beta', local_game_state=<LocalGameState.Installed: 1>)}
```
vs GalaxyClient.log
```
2021-02-01 11:39:08.870 [Information][ (0)] [TID 18436][galaxy_client]: Plugin pluginID/battlenet_ba170431-0649-482f-863b-d248592f1842 started
```

Workaround:
- wait 1s more on start; that should be enough