### PR TITLE
Add support for suspended battlenet games

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
     "guid": "ba170431-0649-482f-863b-d248592f1842",
     "version": "1.3.3",
     "description": "Galaxy Battle.net plugin",
-    "author": "FriendsOfGalaxy; bartok765; wanze; saitho; elkangaroo; jordantram",
+    "author": "FriendsOfGalaxy; bartok765; wanze; saitho; elkangaroo; jordantram; duffyboyo",
     "email": "bartok765@protonmail.com",
     "url": "https://github.com/bartok765/galaxy_blizzard_plugin",
     "script": "plugin.py"

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -277,7 +277,8 @@ class BNetPlugin(Plugin):
                 "Good": LicenseType.SinglePurchase,
                 "Inactive": LicenseType.SinglePurchase,
                 "Banned": LicenseType.SinglePurchase,
-                "Free": LicenseType.FreeToPlay
+                "Free": LicenseType.FreeToPlay,
+                "Suspended": LicenseType.SinglePurchase
             }
             games = {}
 


### PR DESCRIPTION
Noticed a missing state, it was not allowing me to import my battle.net games into galaxy due to one of my games being suspended. 

This fixed my issue and now imports correctly.