### PR TITLE
Add support for Diablo II: Resurrected; add some info to readme on ne…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,9 @@ Unfortunately, games' details must currently be hardcoded for detection, and are
 
 Blizzard games must be added to the map of title IDs with their UID, game name, and product family
 
-Example required data (for Overwatch)
-
-| Product family (for launching) | UID (for installation) | Title ID (for ownership) | Game name |
-| :---: | :-----: | :----: | :----: |
-| Pro | prometheus | 5272175 | Overwatch |
+| Type of Blizzard ID: <br><br> Used for:| Product family <br><br> Launching | UID <br><br> Installation | Title ID <br><br> Ownership detection| Game name <br><br> Proper display in Galaxy |
+| :---: | :-----: | :-----: | :----: | :----: |
+| __Example:__ | Pro | prometheus | 5272175 | Overwatch |
 
 #### Game name
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Unfortunately, games' details must currently be hardcoded for detection, and are
 
 Blizzard games must be added to the map of title IDs with their UID, game name, and product family
 
-| Type of Blizzard ID: <br><br> Used for:| Product family <br><br> Launching | UID <br><br> Installation | Title ID <br><br> Ownership detection| Game name <br><br> Proper display in Galaxy |
+| Type of Blizzard ID: | Product family | UID | Title ID | Game name  |
 | :---: | :-----: | :-----: | :----: | :----: |
+| __Use in plugin:__| Launching | Installation | Ownership detection | Proper display in Galaxy |
 | __Example:__ | Pro | prometheus | 5272175 | Overwatch |
 
 #### Game name

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ To do that, start up Overwatch and navigate to the Options. From there click the
 
 ## Note on Classic Blizzard Games not detected as installed or launching
 
-If you have classic Blizzard games which are not properly detected as installed or don't launch when clicking 'play'
-please provide the name and values of the games key under
+If you have classic Blizzard games which are not properly detected as installed or don't launch when clicking 'play' you can contribute to the project to improve it! Please open an issue and provide the name and values of the game's key which can be found as below:
 
 ```
 Computer\HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\
@@ -50,27 +49,23 @@ If you want to keep imported data (owned games, play time), but do not need to s
 
 ## Help us with game detection
 
-Unfortunately, games' details must currently be hardcoded for detection, and are kept in `definitions.py`. Currently multiple versions of the same game is not supported as ownership is matched 1:1 on UID
-
-### Adding undetected games
+Unfortunately, games' details must currently be hardcoded for detection, and are kept in `definitions.py`
 
 Blizzard games must be added to the map of title IDs with their UID, game name, and product family
 
-#### Example and tips for finding the necessary data
+Example required data (for Overwatch)
 
 | Product family (for launching) | UID (for installation) | Title ID (for ownership) | Game name |
 | :---: | :-----: | :----: | :----: |
 | Pro | prometheus | 5272175 | Overwatch |
 
-
 #### Game name
 
 The game name should match the name in Battle.net exactly, including special characters
 
-
 ##### Product family
 
-Product family may be found in configs (`C:\Users\<user>\AppData\Roaming\Battle.net`) as e.g.
+Product family may be found in configs (in `C:\Users\<user>\AppData\Roaming\Battle.net`) as e.g.
 
     {
         "User": {
@@ -87,7 +82,7 @@ Product family may be found in configs (`C:\Users\<user>\AppData\Roaming\Battle.
 
 ##### UID
 
-UID may be present in `Battle.net.config` in configs directory if the game was installed, as e.g.
+UID may be present in `Battle.net.config` in configs directory (`C:\Users\<user>\AppData\Roaming\Battle.net`) if the game was installed, as e.g.
 
     {
         "Games": {
@@ -102,7 +97,7 @@ This may also be helpful in determining UIDs:
 
 https://wowdev.wiki/TACT#Products (Agent Product is our UID here)
 
-As visible in these tables, multiple versions of a game correspond to different UIDs, **which is currently not supported in plugin architecture for multiple versions in the same region.**
+As visible in these tables, multiple versions of a game correspond to different UIDs, **but in current plugin architecture it is not possible to set ownership for multiple game versions at once.**
 
 ##### Title ID
 
@@ -111,7 +106,6 @@ Title ID can be checked for your games by checking the https://account.battle.ne
 ##### Further notes
 
 Battle.net client logs, which can be found in e.g. `%LOCALAPPDATA%\Battle.net\Logs` may be helpful in providing this information. You _may_ be able to find some information in logs for unowned games.
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -88,3 +88,25 @@ Build zip package with name indicating current version:
 ```bash
 inv pack
 ```
+
+## Adding undetected games
+
+As found in definitions.py, Blizzard games must be added to the map of title IDs with their uID, game name, and product family
+
+#### Example
+
+    5272175: RegionalGameInfo('prometheus', False),    // Title ID: 5272175; uID: prometheus; f2p: False
+        
+    ...
+        
+    BlizzardGame('prometheus', 'Overwatch', 'Pro'),    // uID: prometheus; Game Name: Overwatch; Product Family: Pro
+
+Battle.net client logs, which can be found in e.g. %LOCALAPPDATA%\Battle.net\Logs may be helpful in providing this information.
+
+Title ID can be checked for your games by checking the https://account.battle.net/api/games-and-subs endpoint in a browser while logged in to your Battle.net account
+
+Product family can be found in configs ("C:\Users\<user>\AppData\Roaming\Battle.net"), which may also be helpful for uID
+
+Below links may be helpful in determining these data: 
+
+https://wowdev.wiki/TACT#Products

--- a/README.md
+++ b/README.md
@@ -23,16 +23,7 @@ Currently we only support displaying the total playtime of your quickplay matche
 **Important:** Make sure your Overwatch profile is set to public in order to show your playtime.
 To do that, start up Overwatch and navigate to the Options. From there click the "Social" tab and toggle the option "Career Profile Visibility" to "Public".
 
-
-## Uninstallation (remove all data)
-Click `Disconnect` button in GOG Galaxy Settings. If you see `Connect` instead of `Disconnect` (this may happen on plugin crash or accessing from different machine) you need to connect it again and then disconnect.
-
-### "Soft" disconnect (advanced)
-If you want to keep imported data (owned games, play time), but do not need to sync more and play with local games, you can "turn off" local plugin:
-- close Galaxy
-- remove plugin local database (on Windows usually at `C:\ProgramData\GOG.com\Galaxy\storage\plugins`).
-
-## Help us finding Classic Blizzard Games
+## Note on Classic Blizzard Games not detected as installed or launching
 
 If you have classic Blizzard games which are not properly detected as installed or don't launch when clicking 'play'
 please provide the name and values of the games key under
@@ -48,6 +39,79 @@ If on MAC please provide the games bundle_id which can be found by calling
 ```
 /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -dump | grep {game_name}
 ```
+
+## Uninstallation (remove all data)
+Click `Disconnect` button in GOG Galaxy Settings. If you see `Connect` instead of `Disconnect` (this may happen on plugin crash or accessing from different machine) you need to connect it again and then disconnect.
+
+### "Soft" disconnect (advanced)
+If you want to keep imported data (owned games, play time), but do not need to sync more and play with local games, you can "turn off" local plugin:
+- close Galaxy
+- remove plugin local database (on Windows usually at `C:\ProgramData\GOG.com\Galaxy\storage\plugins`).
+
+## Help us with game detection
+
+Unfortunately, games' details must currently be hardcoded for detection, and are kept in `definitions.py`. Currently multiple versions of the same game is not supported as ownership is matched 1:1 on UID
+
+### Adding undetected games
+
+Blizzard games must be added to the map of title IDs with their UID, game name, and product family
+
+#### Example and tips for finding the necessary data
+
+| Product family (for launching) | UID (for installation) | Title ID (for ownership) | Game name |
+| :---: | :-----: | :----: | :----: |
+| Pro | prometheus | 5272175 | Overwatch |
+
+
+#### Game name
+
+The game name should match the name in Battle.net exactly, including special characters
+
+
+##### Product family
+
+Product family may be found in configs (`C:\Users\<user>\AppData\Roaming\Battle.net`) as e.g.
+
+    {
+        "User": {
+            "Client": {
+                "PlayScreen": {
+                    "GameFamily": {
+                        "WoW": {                <-- Family
+                            "CustomTabOrder": "1"
+                        },
+                        "D3": {
+                            "CustomTabOrder": "2"
+                        },
+                ...
+
+##### UID
+
+UID may be present in `Battle.net.config` in configs directory if the game was installed, as e.g.
+
+    {
+        "Games": {
+            "osi_beta": {
+                "ServerUid": "osi_beta",        <-- UID
+                "LastActioned": "1632131669",
+                "Resumable": "true"
+            }
+    }
+    
+This may also be helpful in determining UIDs: 
+
+https://wowdev.wiki/TACT#Products (Agent Product is our UID here)
+
+As visible in these tables, multiple versions of a game correspond to different UIDs, **which is currently not supported in plugin architecture for multiple versions in the same region.**
+
+##### Title ID
+
+Title ID can be checked for your games by checking the https://account.battle.net/api/games-and-subs endpoint in a browser while logged in to your Battle.net account
+
+##### Further notes
+
+Battle.net client logs, which can be found in e.g. `%LOCALAPPDATA%\Battle.net\Logs` may be helpful in providing this information. You _may_ be able to find some information in logs for unowned games.
+
 
 ## Development
 
@@ -88,25 +152,3 @@ Build zip package with name indicating current version:
 ```bash
 inv pack
 ```
-
-## Adding undetected games
-
-As found in definitions.py, Blizzard games must be added to the map of title IDs with their uID, game name, and product family
-
-#### Example
-
-    5272175: RegionalGameInfo('prometheus', False),    // Title ID: 5272175; uID: prometheus; f2p: False
-        
-    ...
-        
-    BlizzardGame('prometheus', 'Overwatch', 'Pro'),    // uID: prometheus; Game Name: Overwatch; Product Family: Pro
-
-Battle.net client logs, which can be found in e.g. %LOCALAPPDATA%\Battle.net\Logs may be helpful in providing this information.
-
-Title ID can be checked for your games by checking the https://account.battle.net/api/games-and-subs endpoint in a browser while logged in to your Battle.net account
-
-Product family can be found in configs ("C:\Users\<user>\AppData\Roaming\Battle.net"), which may also be helpful for uID
-
-Below links may be helpful in determining these data: 
-
-https://wowdev.wiki/TACT#Products

--- a/src/definitions.py
+++ b/src/definitions.py
@@ -81,7 +81,8 @@ class _Blizzard(object, metaclass=Singleton):
         1279351378: RegionalGameInfo('lazarus', False),
         1514493267: RegionalGameInfo('zeus', False),
         1381257807: RegionalGameInfo('rtro', False),
-        1464615513: RegionalGameInfo('cb4', False)
+        1464615513: RegionalGameInfo('cb4', False),
+        5198665: RegionalGameInfo('osi_vendor_1', False)
     }
     TITLE_ID_MAP_CN = {
         **TITLE_ID_MAP,
@@ -103,7 +104,8 @@ class _Blizzard(object, metaclass=Singleton):
         BlizzardGame('lazarus', 'Call of Duty: MW2 Campaign Remastered', 'LAZR'),
         BlizzardGame('zeus', 'Call of Duty: Black Ops Cold War', 'ZEUS'),
         BlizzardGame('rtro', 'Blizzard Arcade Collection', 'RTRO'),
-        BlizzardGame('cb4', 'Crash Bandicoot 4: It\'s About Time', 'CB4')
+        BlizzardGame('cb4', 'Crash Bandicoot 4: It\'s About Time', 'CB4'),
+        BlizzardGame('osi_vendor_1', 'Diablo® II: Resurrected', 'OSI')
     ]
     CLASSIC_GAMES = [
         ClassicGame('d2', 'Diablo® II', 'Diablo II', 'Diablo II', 'DisplayIcon', "Game.exe", "com.blizzard.diabloii"),


### PR DESCRIPTION
Diablo II: Resurrected should now be detected properly. Additional notes added to readme on adding undetected games.

Fixes #61

## How has this veen tested?

Manually checked that plugin detected D2:R


## Checklist:

- [x] I have added myself to contributor list in `src/manifest.json` (nick or/and full name)
- [x] I have added myself to contributor list in `LICENSE` file (nick or/and full name)
- [x] Unit tests pass locally with my changes

**New Unit Tests**
- [x] I think there is no sense to test my change (apply on consts modification etc.)
