### PR TITLE
Update Crash Bandicoot 4's game id

### DIFF
--- a/src/definitions.py
+++ b/src/definitions.py
@@ -81,7 +81,7 @@ class _Blizzard(object, metaclass=Singleton):
         1279351378: RegionalGameInfo('lazarus', False),
         1514493267: RegionalGameInfo('zeus', False),
         1381257807: RegionalGameInfo('rtro', False),
-        1464615513: RegionalGameInfo('cb4', False),
+        1464615513: RegionalGameInfo('wlby', False),
         5198665: RegionalGameInfo('osi_vendor_1', False)
     }
     TITLE_ID_MAP_CN = {
@@ -104,7 +104,7 @@ class _Blizzard(object, metaclass=Singleton):
         BlizzardGame('lazarus', 'Call of Duty: MW2 Campaign Remastered', 'LAZR'),
         BlizzardGame('zeus', 'Call of Duty: Black Ops Cold War', 'ZEUS'),
         BlizzardGame('rtro', 'Blizzard Arcade Collection', 'RTRO'),
-        BlizzardGame('cb4', 'Crash Bandicoot 4: It\'s About Time', 'CB4'),
+        BlizzardGame('wlby', 'Crash Bandicoot 4: It\'s About Time', 'WLBY'),
         BlizzardGame('osi_vendor_1', 'Diablo® II: Resurrected', 'OSI')
     ]
     CLASSIC_GAMES = [


### PR DESCRIPTION
Fixes Crash Bandicoot 4 never appearing as installed

The game's id should have been 'WLBY', also fixes the game not appearing as installed