### PR TITLE
Fix incorrect UID for Diablo II: Resurrected

### DIFF
--- a/src/definitions.py
+++ b/src/definitions.py
@@ -82,7 +82,7 @@ class _Blizzard(object, metaclass=Singleton):
         1514493267: RegionalGameInfo('zeus', False),
         1381257807: RegionalGameInfo('rtro', False),
         1464615513: RegionalGameInfo('wlby', False),
-        5198665: RegionalGameInfo('osi_vendor_1', False)
+        5198665: RegionalGameInfo('osi', False)
     }
     TITLE_ID_MAP_CN = {
         **TITLE_ID_MAP,
@@ -105,7 +105,7 @@ class _Blizzard(object, metaclass=Singleton):
         BlizzardGame('zeus', 'Call of Duty: Black Ops Cold War', 'ZEUS'),
         BlizzardGame('rtro', 'Blizzard Arcade Collection', 'RTRO'),
         BlizzardGame('wlby', 'Crash Bandicoot 4: It\'s About Time', 'WLBY'),
-        BlizzardGame('osi_vendor_1', 'Diablo® II: Resurrected', 'OSI')
+        BlizzardGame('osi', 'Diablo® II: Resurrected', 'OSI')
     ]
     CLASSIC_GAMES = [
         ClassicGame('d2', 'Diablo® II', 'Diablo II', 'Diablo II', 'DisplayIcon', "Game.exe", "com.blizzard.diabloii"),


### PR DESCRIPTION
## Description
Diablo II: Resurrected has an incorrect UID and it needs updating to detect installation / launch properly.
Fixes #

Fixes D2:R not being playable from Galaxy

## How has this veen tested?

Tested manually, swapping ID launched successfully.

-

## Checklist:

- [x] I have added myself to contributor list in `src/manifest.json` (nick or/and full name)
- [x] I have added myself to contributor list in `LICENSE` file (nick or/and full name)
- [x] Unit tests pass locally with my changes

**New Unit Tests**
- [ ] I have added/modified unit tests to cover my change
- [x] I think there is no sens to test my change (apply on consts modification etc.)
- [ ] I need some help to accomplish
